### PR TITLE
Add TeamCity extension

### DIFF
--- a/nunit-install.sln
+++ b/nunit-install.sln
@@ -5,6 +5,11 @@ VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "nunit", "nunit\nunit.wixproj", "{809C00DC-3FD3-45BF-BC0E-E284F314D306}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FEC80CC8-E48A-41D2-ACBF-1C8C9FAD5E1F}"
+	ProjectSection(SolutionItems) = preProject
+		build.cake = build.cake
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86

--- a/nunit/addin-files.wxi
+++ b/nunit/addin-files.wxi
@@ -22,6 +22,13 @@
             </Component>
         </ComponentGroup>
 
+        <ComponentGroup Id="TEAMCITY.EVENT.LISTENER" Directory="ADDINS">
+            <Component Id="TEAMCITY.EVENT.LISTENER" Location="local" Guid="F7A37F5B-2D83-4B82-83E9-5A4EC0CBEB2F">
+                <File Id="teamcity_event_listener.dll"
+                      Source="$(var.InstallImage)\teamcity-event-listener.dll" />
+            </Component>
+        </ComponentGroup>
+
         <ComponentGroup Id="NUNIT.V2.DRIVER" Directory="ADDINS">
             <Component Id="NUNIT.V2.DRIVER" Location="local" Guid="4A55D836-7719-40A2-BDFF-CE3980FE3B42">
                 <File Id="nunit.v2.driver.dll"

--- a/nunit/runner-features.wxi
+++ b/nunit/runner-features.wxi
@@ -37,6 +37,12 @@
                         Description="Allows you to write test results out in the NUnit 2.x format">
                 <ComponentGroupRef Id="ADDINS.NUNIT.V2.WRITER" />
             </Feature>
+            <Feature Id="TEAMCITY.EVENT.LISTENER"
+                     Level="1"
+                     Title="TeamCity Event Listener"
+                     Description="Provides progress messages when running under TeamCity">
+                <ComponentGroupRef Id="TEAMCITY.EVENT.LISTENER" />
+             </Feature>
         </Feature>
 
         <Feature Id="NUNIT.CONSOLE"


### PR DESCRIPTION
Fixes #2.

Added exactly as before, with the exception that when this extension was last in the msi (v3.4.1), it was missing the GUID. I think this caused problems with removing the dll on uninstall.

Have given it a fresh guid now - it doesn't seem to cause any file overwrite problems for me. 
