### PR TITLE
Add zip distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,8 @@ $RECYCLE.BIN/
 
 distribution/
 image/
-packages/
+extension-packages/
+runner-packages/
 tools/*
 !tools/packages.config
 nunit/bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,4 +2,5 @@ build_script:
   - ps: .\build.ps1 -Target "Appveyor"
 
 artifacts:
-- path: distribution\*.msi
+- path: distribution\*.msi 
+- path: distribution\*.zip

--- a/nunit/addin-files.wxi
+++ b/nunit/addin-files.wxi
@@ -4,43 +4,43 @@
         <ComponentGroup Id="ADDINS.NUNIT.PROJECT.LOADER" Directory="ADDINS">
             <Component Id="ADDINS.NUNIT.PROJECT.LOADER" Location="local" Guid="294BEC17-144D-403B-A08C-E524BE8F3FA3">
                 <File Id="nunit_project_loader.dll"
-                      Source="$(var.InstallImage)\nunit-project-loader.dll" />
+                      Source="$(var.InstallImage)addins\nunit-project-loader.dll" />
             </Component>
         </ComponentGroup>
 
         <ComponentGroup Id="ADDINS.VS.PROJECT.LOADER" Directory="ADDINS">
             <Component Id="ADDINS.VS.PROJECT.LOADER" Location="local" Guid="98CB680E-EAFA-4DC6-A0C1-030734A4C949">
                 <File Id="vs_project_loader.dll"
-                      Source="$(var.InstallImage)\vs-project-loader.dll" />
+                      Source="$(var.InstallImage)addins\vs-project-loader.dll" />
             </Component>
         </ComponentGroup>
 
         <ComponentGroup Id="ADDINS.NUNIT.V2.WRITER" Directory="ADDINS">
             <Component Id="ADDINS.NUNIT.V2.WRITER" Location="local" Guid="9CD93A4A-A499-4DC9-9E07-A95D9743D06F">
                 <File Id="nunit_v2_result_writer.dll"
-                      Source="$(var.InstallImage)\nunit-v2-result-writer.dll" />
+                      Source="$(var.InstallImage)addins\nunit-v2-result-writer.dll" />
             </Component>
         </ComponentGroup>
 
         <ComponentGroup Id="TEAMCITY.EVENT.LISTENER" Directory="ADDINS">
             <Component Id="TEAMCITY.EVENT.LISTENER" Location="local" Guid="F7A37F5B-2D83-4B82-83E9-5A4EC0CBEB2F">
                 <File Id="teamcity_event_listener.dll"
-                      Source="$(var.InstallImage)\teamcity-event-listener.dll" />
+                      Source="$(var.InstallImage)addins\teamcity-event-listener.dll" />
             </Component>
         </ComponentGroup>
 
         <ComponentGroup Id="NUNIT.V2.DRIVER" Directory="ADDINS">
             <Component Id="NUNIT.V2.DRIVER" Location="local" Guid="4A55D836-7719-40A2-BDFF-CE3980FE3B42">
                 <File Id="nunit.v2.driver.dll"
-                      Source="$(var.InstallImage)\nunit.v2.driver.dll" />
+                      Source="$(var.InstallImage)addins\nunit.v2.driver.dll" />
             </Component>
             <Component Id="NUNIT.2.CORE" Location="local" Guid="3D13540C-83E0-463A-8FD1-BE2A3248E2EC">
                 <File Id="nunit.core.dll"
-                      Source="$(var.InstallImage)\nunit.core.dll" />
+                      Source="$(var.InstallImage)addins\nunit.core.dll" />
             </Component>
             <Component Id="NUNIT.2.CORE.INTERFACES" Location="local" Guid="A09CA3D7-1D35-436C-A899-E1364B1E7AFD">
                 <File Id="nunit.core.interfaces.dll"
-                      Source="$(var.InstallImage)\nunit.core.interfaces.dll" />
+                      Source="$(var.InstallImage)addins\nunit.core.interfaces.dll" />
             </Component>
         </ComponentGroup>
     </Fragment>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.15.2" />
+    <package id="Cake" version="0.16.1" />
 </packages>


### PR DESCRIPTION
Creates a zip distribution of the contents installed by the msi - fixes nunit/nunit-console#77.

This require a slightly larger rewrite than I expected, to make sure that the extensions ended up in a `addins` subdirectory, so that the paths in nunit.engine.addins were still valid in the zip. 

The zip for 3.4.1 also included tests - but of course we can't do that with this sort of NuGet approach. None of our other distributions include tests, does it seem reasonable that tests become only build-from-source?

As said elsewhere, I'm going away for the weekend tonight, if further changes are needed, please feel free to take over - sorry!
