### PR TITLE
Rename as NUnit.Console

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -42,7 +42,7 @@ var EXTENSION_PACKAGES_DIR = ROOT_DIR + "extension-packages/";
 var DISTRIBUTION_DIR = ROOT_DIR + "distribution/";
 var IMAGE_DIR = ROOT_DIR + "image/";
 var IMAGE_ADDINS_DIR = IMAGE_DIR + "addins/";
-var ZIP_FILE = string.Format("{0}NUnit.{1}.zip", DISTRIBUTION_DIR, version);
+var ZIP_FILE = string.Format("{0}NUnit.Console-{1}.zip", DISTRIBUTION_DIR, version);
 
 //////////////////////////////////////////////////////////////////////
 // TASK

--- a/nunit/nunit.wixproj
+++ b/nunit/nunit.wixproj
@@ -12,7 +12,7 @@
     <SuppressIces>ICE61</SuppressIces>
     <ProjectGuid>809C00DC-3FD3-45BF-BC0E-E284F314D306</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
-    <OutputName>NUnit.$(Version)</OutputName>
+    <OutputName>NUnit.Console-$(Version)</OutputName>
     <OutputType>Package</OutputType>
     <DefineSolutionProperties>false</DefineSolutionProperties>
     <WixTargetsPath Condition=" '$(WixTargetsPath)' == '' AND '$(MSBuildExtensionsPath32)' != '' ">$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets</WixTargetsPath>

--- a/nunit/nunit.wxs
+++ b/nunit/nunit.wxs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*"
-             Name="NUnit $(var.DisplayVersion)"
+             Name="NUnit Console $(var.DisplayVersion)"
              Language="1033"
              Version="$(var.Version)"
              Manufacturer="nunit.org"


### PR DESCRIPTION
Renames the msi and zip from "NUnit" to "NUnit.Console". Fixes #9 

Minor point - I'm aware 'NUnit convention' is `{Name}-{Version}`. However, as NuGet requires `{Name}.{Version}`, I thought it would be an improvement for everything to use the period, rather than have a mix of periods and hyphens. Wouldn't be worth the disruption to change on it's own, but I thought as we're changing package names anyway, this might be nicer going forward. 😄 

Options Framework PR incoming.