### PR TITLE
Exclude any additional .addins files from NuGet packages

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -60,6 +60,7 @@ Task("Clean")
     CleanDirectory(RUNNER_PACKAGES_DIR);
     CleanDirectory(EXTENSION_PACKAGES_DIR);
     CleanDirectory(IMAGE_DIR);
+    CleanDirectory(IMAGE_ADDINS_DIR);
     CleanDirectory(DISTRIBUTION_DIR);
 });
 
@@ -163,8 +164,8 @@ public string[] GetAllDirectories(string dirPath)
 
 public void CopyPackageContents(DirectoryPath packageDir, DirectoryPath outDir)
 {
-    var tools = packageDir + "/tools";
-	CopyDirectory(tools, outDir);
+    var files = GetFiles(packageDir + "/tools/*");
+    CopyFiles(files.Where(f => f.GetExtension() != ".addins"), outDir);
 }
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #17. The zip file now includes only the .addins file stored in this repository, and excludes a couple of additional ones which were being copied inadvertently from the NuGet packages.